### PR TITLE
Fix silent failure in transcript loading with proper error handling

### DIFF
--- a/helpers/youtubeloader.py
+++ b/helpers/youtubeloader.py
@@ -3,8 +3,16 @@ from langchain_core.documents import Document
 
 def load_youtube_transcript(youtube_url: str) -> list[Document]:
     """Loads a YouTube video transcript and returns it as a list of Langchain documents."""
+    
+    # Validate URL
+    if not youtube_url or "v=" not in youtube_url:
+        raise ValueError("Invalid YouTube URL format. Must contain 'v=' parameter.")
+    
     try:
         video_id = youtube_url.split("v=")[1].split("&")[0]
+        
+        if not video_id or len(video_id) != 11:
+            raise ValueError(f"Invalid video ID extracted: {video_id}")
         
         # Use the list_transcripts method to get a list of available transcripts
         transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
@@ -15,7 +23,13 @@ def load_youtube_transcript(youtube_url: str) -> list[Document]:
         # Fetch the actual transcript content
         transcript_data = transcript.fetch()
         
+        if not transcript_data:
+            raise ValueError("No transcript data found for this video")
+        
         full_text = " ".join([d['text'] for d in transcript_data])
+        
+        if not full_text.strip():
+            raise ValueError("Transcript is empty or contains no text")
         
         # Create a single Langchain Document
         doc = Document(page_content=full_text, metadata={"source": youtube_url})
@@ -23,5 +37,4 @@ def load_youtube_transcript(youtube_url: str) -> list[Document]:
         return [doc]
         
     except Exception as e:
-        print(f"Error loading transcript: {e}")
-        return []
+        raise Exception(f"Failed to load YouTube transcript: {str(e)}")


### PR DESCRIPTION
Fixes the "No chunks provided to create vectorstore" error by replacing silent failures with proper error handling and validation in the YouTube transcript loader.
